### PR TITLE
There is a compilation error in this commit, so discard this.

### DIFF
--- a/ospfd/ospf_abr.c
+++ b/ospfd/ospf_abr.c
@@ -1140,7 +1140,8 @@ ospf_abr_announce_rtr_to_area (struct prefix_ipv4 *p, u_int32_t cost,
 		   GET_METRIC (slsa->metric), cost);
     }
 
-  if (old && (GET_METRIC (slsa->metric) == cost))
+  if (old && (GET_METRIC (slsa->metric) == cost)
+      ((old->flags & OSPF_LSA_IN_MAXAGE) == 0))
     {
       if (IS_DEBUG_OSPF_EVENT)
 	zlog_debug ("ospf_abr_announce_rtr_to_area(): old summary approved");


### PR DESCRIPTION
This fix is for Type-4 LS updates handling at a ABR router where 
ospf daemon is not distributing Type-4 LS updates with correct LS-Age 
after learning about a ASBR router in a ospf network. Because of this 
Type-5 LS updates are not learnt in ospf network.
Testing Scenario:
This can be re-produced by restarting the ospfd daemon on DUT 
(mentioned in figure below)before the Hello time interval expires 
for area 0.0.0.1.

 ____                       _______                       ____                    _________
|    |   area: 0.0.0.1     |       |   area: 0.0.0.0     |    |   area: 0.0.0.2  |         |
| R1 |---------------------|DUT/ABR|---------------------| R2 |------------------| R3/ASBR |
|____|     x.x.x.0/24      |_______|    y.y.y.0/64       |____|     z.z.z.0/24   |_________|

In the above setup when ospfd is restarted (imp:before the Hello interval
at R1 expires) and DUT learns about ASBR router R3 (Type-4) in the 
network from R2, but this ls-update is not propagates in area
0.0.0.1. So R1 never comes to know about the ASBR router in the 
network, so all the type-5 LS updates coming from R3 are not learnt
by R1. Further if we again restart ospfd daemon it starts working fine.
With the fix given this issue can be resolved.

More Discussion on this is available at:
http://www.gossamer-threads.com/lists/quagga/dev/23892
